### PR TITLE
don't use multiline string for browser auth

### DIFF
--- a/addons/gift/gift_node.gd
+++ b/addons/gift/gift_node.gd
@@ -183,11 +183,7 @@ func get_token() -> void:
 	if (scopes.size() > 0):
 		scope += scopes[scopes.size() - 1]
 	scope = scope.uri_encode()
-	OS.shell_open("https://id.twitch.tv/oauth2/authorize
-	?response_type=code
-	&client_id=" + client_id +
-	"&redirect_uri=http://localhost:18297
-	&scope=" + scope)
+	OS.shell_open("https://id.twitch.tv/oauth2/authorize?response_type=code&client_id=" + client_id +"&redirect_uri=http://localhost:18297&scope=" + scope)
 	server.listen(18297)
 	print("Waiting for user to login.")
 	while(!peer):


### PR DESCRIPTION
currently, if the user tries to authenticate with `Gift.authenticate()`, the browser will open a malformed URL and return a 404 because the URL string contains multiple lines and indentation:
```gdscript
	OS.shell_open("https://id.twitch.tv/oauth2/authorize
	?response_type=code
	&client_id=" + client_id +
	"&redirect_uri=http://localhost:18297
	&scope=" + scope)
```
this PR fixes it by not using a multiline string. it's not the prettiest to be on one line, so if you'd like a better way to do it while keeping it free of tab characters and newlines i'm open to suggestions 🙂