### PR TITLE
Automatically close out browser window after authentication is done

### DIFF
--- a/addons/gift/auth/grant_flows/redirecting_flow.gd
+++ b/addons/gift/auth/grant_flows/redirecting_flow.gd
@@ -54,7 +54,7 @@ func _handle_empty_response() -> void:
 func _handle_success(data : Dictionary) -> void:
 	data["scope"] = data["scope"].uri_decode().split(" ")
 	print("Success.")
-	send_response("200 OK", "<html><head><title>Twitch Login</title></head><body>Success!</body></html>".to_utf8_buffer())
+	send_response("200 OK", "<html><head><title>Twitch Login</title></head><body onload=\"javascript:close()\">Success!</body></html>".to_utf8_buffer())
 
 func _handle_error(data : Dictionary) -> void:
 	var msg = "Error %s: %s" % [data["error"], data["error_description"]]


### PR DESCRIPTION
ADDED: Automatically close the browser response window if authentication was successful.

When the authentication process is successful, currently you're left with an extra browser window/tab that has no useful information in it.  Proposed pull will automatically close the tab once the authentication flow is complete.